### PR TITLE
BUGFIX handle classroom download errors

### DIFF
--- a/classroom-api/src/classroom-api.ts
+++ b/classroom-api/src/classroom-api.ts
@@ -3,15 +3,18 @@ import { Authenticator } from './authenticate'
 import fs from "fs";
 import path from "path";
 
-export function downloadFile(drive: drive_v3.Drive, id: string): Promise<any> {
+export const downloadError: string = "error saving downloaded file"
+export function downloadFile(drive: drive_v3.Drive, id: string, path?: string): Promise<any> {
     return new Promise((resolve, reject) => {
         drive.files.get({
             fileId: id,
             alt: 'media'
         }, {responseType: 'stream'}, (err, res) => {
-            if (err) {
-                console.log('Drive API returned an error :' + err)
-                reject(err)
+	    if (err ||  !res) {
+	    	if (path) console.log(path)
+		console.log(id + ': Drive API returned an error :' + err)
+                reject(downloadError)
+		return // 😶
             }
             resolve(res!.data)
         })
@@ -23,7 +26,8 @@ export function downloadZip(drive: drive_v3.Drive, id: string, path: string): Pr
 }
 
 export function saveFile(drive: drive_v3.Drive, id: string, filePath: string): Promise<string> {
-    return downloadFile(drive, id)
+	console.log(id, filePath)
+    return downloadFile(drive, id, filePath)
         .then((dataStream: any) => {
             return new Promise((resolve, reject) => {
                 const dest = fs.createWriteStream(filePath);

--- a/classroom-api/src/index.ts
+++ b/classroom-api/src/index.ts
@@ -11,6 +11,7 @@ export * from './students'
 export * from './mailer'
 export { downloadAll, downloadSome, downloadAtInterval } from './downloadHW'
 export { Authenticator } from './authenticate'
+export { downloadError } from './classroom-api'
 
 export async function getSubmissions(subject: string, homework: string, studentList: StudentList, auth: Authenticator): Promise<Submission[]> {
 	let classroom = await ClassroomApi.findClass(subject, auth)

--- a/main-module/src/homeworkChecker.ts
+++ b/main-module/src/homeworkChecker.ts
@@ -1,5 +1,5 @@
 import {Submission} from "dt-types";
-import {Drive} from 'classroom-api'
+import {Drive, downloadError} from 'classroom-api'
 import {log, Run} from "./runs";
 
 import path from 'path'
@@ -77,7 +77,7 @@ async function downloadAndTest(submission: Submission, drive: Drive, index: numb
 */
 function logError(submission: Submission, error: any) {
     // LATER ცალკე კლასი იქნება ერორების და იმის მიხედვით
-    const knownErrors = [zipFormatError, fileNotFoundError, filesNotFoundError, teamNameNotFoundError]
+    const knownErrors = [zipFormatError, downloadError, fileNotFoundError, filesNotFoundError, teamNameNotFoundError]
     if (knownErrors.includes(error)) {
         submission.incorrectFormat = true
         submission.results.push({

--- a/main-module/src/modules/karel.ts
+++ b/main-module/src/modules/karel.ts
@@ -13,18 +13,18 @@ function downloadAtInterval(submission: Submission, drive: Drive,  index: number
     const fileName = attachment.title
     const id = attachment.id
     const path = `${run.moveDir}/${fileName}`
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         setTimeout(() => {
             if (run.opts.download) {
                 if (process.env.NODE_ENV === 'production')
                     console.log(`${submission.emailId}: downloading`)
                 saveFile(drive, id, path)
                     .then(() => resolve(path))
+                    .catch((err: any) => reject(err))
             } else {
                 resolve(path)
             }
         }, (index) * 200)
-
     })
 }
 


### PR DESCRIPTION
saveFile-ის გამოძახებისას თუ გადაწოდებული id არ არის ტექსტური ფაილი და არის, მაგალითად, *sigh*, google doc, გადმოწერის დროს data არის undefined. 

გარდა ამისა, კარელის მოდულის downloadAtInterval ფაილში ავტორს (მე) იმდენად არც კი დაუშვია რომ ფაილის გადმოწერისას რამე შეცდომა შეიძლება მოხდეს, რომ Promise-ის შექმნისას reject-ის ვარიანტი საერთოდ არ არსებობს.

გადმოწერის ერორი აქამდეც მხოლოდ მსგავს პრობლემებზე იყო, ანუ როდესაც ინსტრუქცია უხეშად დაარღვიეს. ამიტომ ამ ეტაპზე known error-ებში დავამატე, მხოლოდ ეგ და rejection-ის გადაცემა იყო საჭირო და logError ფუნქცია თავისით დაიჭერს

გარდა ამისა ასევე მნიშვნელოვანია რომ ასინქრონული გადმოწერების დროს ვიცოდეთ ერორი კონკრეტულად რომელ id-ზე მოხდა, ამიტომ log-ში ჩავრთავ.